### PR TITLE
Fix ruff invocation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
           python-version: '3.12'
       - run: sudo apt-get update && sudo apt-get install -y potrace libagg-dev libpotrace-dev
       - run: pip install -r requirements.txt ruff black pytest
-      - run: ruff --fix .
+      - run: ruff check --fix .
       - run: black --check .
       - run: pytest --maxfail=1 --disable-warnings
       - run: |


### PR DESCRIPTION
## Summary
- update CI to run `ruff check --fix` for Ruff v0.11+

## Testing
- `ruff check .`
- `black --check .`
- `pytest --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_b_6840975d9e8c832db26e73ab5ea97b27