### PR TITLE
Fix tests by including httpx

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ Then install Python dependencies and run the tests:
 pip install -r requirements.txt
 pytest
 ```
+The `requirements.txt` file now lists `httpx`, required by the
+`fastapi.testclient` used in the tests.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 fastapi
 uvicorn
+httpx
 pillow
 pypotrace
 python-multipart


### PR DESCRIPTION
## Summary
- add `httpx` dependency for the FastAPI TestClient
- document the new requirement in the README

## Testing
- `pytest --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_b_6840d2c8d364832da5f6835f582fdd38