### PR TITLE
Enable GET endpoint for vectorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Responses:
 - `400` on invalid input or download errors
 - `401` if authorization fails
 
+### `GET /vectorize`
+
+Vectorize an image by specifying its `image_url` in the query string. This makes
+it possible to call the service directly from a web browser. The same query
+parameters as the POST endpoint are supported and the response format is
+identical.
+
 ### `GET /healthz`
 
 Simple liveness probe returning `{"status": "ok"}`.
@@ -45,6 +52,9 @@ curl -F image=@test.png http://localhost:8080/vectorize
 
 # via URL
 curl -X POST "http://localhost:8080/vectorize?image_url=https://example.com/img.png"
+
+# GET request (paste in browser)
+http://localhost:8080/vectorize?image_url=https://example.com/img.png
 
 # download result
 curl -F image=@test.png "http://localhost:8080/vectorize?download=true" -o out.svg

--- a/app/main.py
+++ b/app/main.py
@@ -70,6 +70,31 @@ async def vectorize(
     return JSONResponse({"svg": svg})
 
 
+@app.get("/vectorize", response_model=None)
+async def vectorize_get(
+    request: Request,
+    image_url: str = Query(...),
+    threshold: int = Query(128, ge=0, le=255),
+    turnpolicy: str = Query("minority"),
+    alphamax: float = Query(1.0),
+    turdsize: int = Query(2),
+    fill: str | None = Query(None),
+    download: bool = Query(False),
+) -> Response | JSONResponse:
+    """Vectorize an image from a URL via a GET request."""
+    return await vectorize(
+        request=request,
+        image=None,
+        image_url=image_url,
+        threshold=threshold,
+        turnpolicy=turnpolicy,
+        alphamax=alphamax,
+        turdsize=turdsize,
+        fill=fill,
+        download=download,
+    )
+
+
 @app.get("/healthz")
 def healthz() -> dict[str, str]:
     return {"status": "ok"}

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -31,3 +31,12 @@ def test_vectorize_image_url() -> None:
         resp = client.post("/vectorize?image_url=http://example.com/img.png")
     assert resp.status_code == 200
     assert "<svg" in resp.json()["svg"]
+
+
+def test_vectorize_image_url_get() -> None:
+    client = TestClient(app)
+    with patch("urllib.request.urlopen", return_value=_Resp()):
+        resp = client.get("/vectorize?image_url=http://example.com/img.png")
+    assert resp.status_code == 200
+    assert "<svg" in resp.json()["svg"]
+


### PR DESCRIPTION
## Summary
- allow vectorization by GET using a required image URL
- document new endpoint in README
- add GET example in usage section
- test GET `/vectorize`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6841496d5724832d87c2d1399b75f33d