### PR TITLE
Add token query parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This will launch the app on [http://localhost:8080](http://localhost:8080).
 
 ### `POST /vectorize`
 
-Convert an image to SVG. The image can be uploaded as multipart form data (`image` field) or specified via `image_url` query parameter. If `API_TOKEN` is set, include an `Authorization: Bearer <token>` header.
+Convert an image to SVG. The image can be uploaded as multipart form data (`image` field) or specified via `image_url` query parameter. If `API_TOKEN` is set, include an `Authorization: Bearer <token>` header or pass `token=<token>` in the query string.
 
 **Query parameters**
 
@@ -38,7 +38,8 @@ Responses:
 Vectorize an image by specifying its `image_url` in the query string. This makes
 it possible to call the service directly from a web browser. The same query
 parameters as the POST endpoint are supported and the response format is
-identical.
+identical. If an `API_TOKEN` is configured, include `token=<token>` in the query
+string (or send the `Authorization` header) when calling this endpoint.
 
 ### `GET /healthz`
 
@@ -53,8 +54,14 @@ curl -F image=@test.png http://localhost:8080/vectorize
 # via URL
 curl -X POST "http://localhost:8080/vectorize?image_url=https://example.com/img.png"
 
+# with Authorization header
+curl -H "Authorization: Bearer secret" -F image=@test.png http://localhost:8080/vectorize
+
 # GET request (paste in browser)
 http://localhost:8080/vectorize?image_url=https://example.com/img.png
+
+# GET request with token
+http://localhost:8080/vectorize?image_url=https://example.com/img.png&token=secret
 
 # download result
 curl -F image=@test.png "http://localhost:8080/vectorize?download=true" -o out.svg
@@ -62,7 +69,7 @@ curl -F image=@test.png "http://localhost:8080/vectorize?download=true" -o out.s
 
 ## Environment variables
 
-- `API_TOKEN` (optional) – Bearer token required for calls to `/vectorize` when set.
+- `API_TOKEN` (optional) – Bearer token required for calls to `/vectorize` when set. Supply it via the `Authorization` header or a `token` query parameter.
 
 ## Deployment
 

--- a/app/main.py
+++ b/app/main.py
@@ -16,9 +16,12 @@ API_TOKEN = os.getenv("API_TOKEN")
 
 
 def _check_auth(request: Request) -> None:
-    """Validate Authorization header against the API token if configured."""
+    """Validate auth token from header or query string if configured."""
     header = request.headers.get("Authorization")
-    if API_TOKEN and header != f"Bearer {API_TOKEN}":
+    token_param = request.query_params.get("token")
+    if API_TOKEN and not (
+        header == f"Bearer {API_TOKEN}" or token_param == API_TOKEN
+    ):
         raise HTTPException(status_code=401, detail="Unauthorized")
 
 

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -39,3 +39,24 @@ def test_vectorize_image_url_get() -> None:
         resp = client.get("/vectorize?image_url=http://example.com/img.png")
     assert resp.status_code == 200
     assert "<svg" in resp.json()["svg"]
+
+
+def test_auth_header() -> None:
+    with patch("app.main.API_TOKEN", "secret"):
+        client = TestClient(app)
+        resp = client.post(
+            "/vectorize",
+            headers={"Authorization": "Bearer secret"},
+            files={"image": ("img.png", _img_bytes(), "image/png")},
+        )
+        assert resp.status_code == 200
+
+
+def test_auth_query_param() -> None:
+    with patch("app.main.API_TOKEN", "secret"):
+        client = TestClient(app)
+        resp = client.post(
+            "/vectorize?token=secret",
+            files={"image": ("img.png", _img_bytes(), "image/png")},
+        )
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- allow passing API token via `token` query parameter
- cover token query param and header in tests
- document how to use API token with GET/POST endpoints and in cURL examples

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68425b8746e4832da0ad8dc5f44393d1