### PR TITLE
Support multiple image formats in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vectorize-svc
 
-FastAPI micro-service for converting raster images to SVG paths using [potrace](http://potrace.sourceforge.net/). It exposes a single HTTP endpoint that accepts an image file or URL and returns the traced SVG data.
+FastAPI micro-service for converting raster images to SVG paths using [potrace](http://potrace.sourceforge.net/). It exposes a single HTTP endpoint that accepts an image file or URL and returns the traced SVG data. Any format supported by Pillow (PNG, JPEG, WebP, etc.) can be used as input.
 
 ## Quick start with Docker
 
@@ -49,6 +49,7 @@ Remove the variable entirely if you want to run the service without auth.
 ### `POST /vectorize`
 
 Convert an image to SVG. The image can be uploaded as multipart form data (`image` field) or specified via `image_url` query parameter. If `API_TOKEN` is set, include an `Authorization: Bearer <token>` header or pass `token=<token>` in the query string.
+Supported input types include PNG, JPEG, WebP, and any other format that Pillow can decode.
 
 **Query parameters**
 

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -1,20 +1,25 @@
 import io
 from unittest.mock import patch
+
+import pytest
 from PIL import Image
 from fastapi.testclient import TestClient
 
 from app.main import app
 
 
-def _img_bytes() -> bytes:
+def _img_bytes(fmt: str = "PNG") -> bytes:
     img = Image.new("RGB", (2, 2), "white")
     img.putpixel((0, 0), (0, 0, 0))
     buf = io.BytesIO()
-    img.save(buf, format="PNG")
+    img.save(buf, format=fmt)
     return buf.getvalue()
 
 
 class _Resp:
+    def __init__(self, fmt: str = "PNG"):
+        self.fmt = fmt
+
     def __enter__(self):
         return self
 
@@ -22,52 +27,92 @@ class _Resp:
         pass
 
     def read(self) -> bytes:
-        return _img_bytes()
+        return _img_bytes(self.fmt)
 
 
-def test_vectorize_image_url() -> None:
+@pytest.mark.parametrize(
+    "fmt,ext",
+    [
+        ("PNG", "png"),
+        ("JPEG", "jpg"),
+        ("WEBP", "webp"),
+    ],
+)
+def test_vectorize_image_url(fmt: str, ext: str) -> None:
     client = TestClient(app)
-    with patch("urllib.request.urlopen", return_value=_Resp()):
-        resp = client.post("/vectorize?image_url=http://example.com/img.png")
+    with patch("urllib.request.urlopen", return_value=_Resp(fmt)):
+        resp = client.post(f"/vectorize?image_url=http://example.com/img.{ext}")
     assert resp.status_code == 200
     assert "<svg" in resp.json()["svg"]
 
 
-def test_vectorize_image_url_get() -> None:
+@pytest.mark.parametrize(
+    "fmt,ext",
+    [
+        ("PNG", "png"),
+        ("JPEG", "jpg"),
+        ("WEBP", "webp"),
+    ],
+)
+def test_vectorize_image_url_get(fmt: str, ext: str) -> None:
     client = TestClient(app)
-    with patch("urllib.request.urlopen", return_value=_Resp()):
-        resp = client.get("/vectorize?image_url=http://example.com/img.png")
+    with patch("urllib.request.urlopen", return_value=_Resp(fmt)):
+        resp = client.get(f"/vectorize?image_url=http://example.com/img.{ext}")
     assert resp.status_code == 200
     assert "<svg" in resp.json()["svg"]
 
 
-def test_auth_header() -> None:
+@pytest.mark.parametrize(
+    "fmt,mime,ext",
+    [
+        ("PNG", "image/png", "png"),
+        ("JPEG", "image/jpeg", "jpg"),
+        ("WEBP", "image/webp", "webp"),
+    ],
+)
+def test_auth_header(fmt: str, mime: str, ext: str) -> None:
     with patch("app.main.API_TOKEN", "secret"):
         client = TestClient(app)
         resp = client.post(
             "/vectorize",
             headers={"Authorization": "Bearer secret"},
-            files={"image": ("img.png", _img_bytes(), "image/png")},
+            files={"image": (f"img.{ext}", _img_bytes(fmt), mime)},
         )
         assert resp.status_code == 200
 
 
-def test_auth_query_param() -> None:
+@pytest.mark.parametrize(
+    "fmt,mime,ext",
+    [
+        ("PNG", "image/png", "png"),
+        ("JPEG", "image/jpeg", "jpg"),
+        ("WEBP", "image/webp", "webp"),
+    ],
+)
+def test_auth_query_param(fmt: str, mime: str, ext: str) -> None:
     with patch("app.main.API_TOKEN", "secret"):
         client = TestClient(app)
         resp = client.post(
             "/vectorize?token=secret",
-            files={"image": ("img.png", _img_bytes(), "image/png")},
+            files={"image": (f"img.{ext}", _img_bytes(fmt), mime)},
         )
         assert resp.status_code == 200
 
 
-def test_auth_query_param_get() -> None:
+@pytest.mark.parametrize(
+    "fmt,ext",
+    [
+        ("PNG", "png"),
+        ("JPEG", "jpg"),
+        ("WEBP", "webp"),
+    ],
+)
+def test_auth_query_param_get(fmt: str, ext: str) -> None:
     """Ensure token works when using GET /vectorize."""
     with patch("app.main.API_TOKEN", "secret"):
         client = TestClient(app)
-        with patch("urllib.request.urlopen", return_value=_Resp()):
+        with patch("urllib.request.urlopen", return_value=_Resp(fmt)):
             resp = client.get(
-                "/vectorize?image_url=http://example.com/img.png&token=secret"
+                f"/vectorize?image_url=http://example.com/img.{ext}&token=secret"
             )
         assert resp.status_code == 200

--- a/app/tests/test_tracing.py
+++ b/app/tests/test_tracing.py
@@ -8,21 +8,23 @@ from PIL import Image
 from app.core.tracing import apply_fill, raster_to_svg
 
 
-def _sample_image() -> bytes:
+def _sample_image(fmt: str = "PNG") -> bytes:
     img = Image.new("RGB", (2, 2), "white")
     img.putpixel((0, 0), (0, 0, 0))
     buf = io.BytesIO()
-    img.save(buf, format="PNG")
+    img.save(buf, format=fmt)
     return buf.getvalue()
 
 
-def test_svg_generation() -> None:
-    svg = raster_to_svg(_sample_image())
+@pytest.mark.parametrize("fmt", ["PNG", "JPEG", "WEBP"])
+def test_svg_generation(fmt: str) -> None:
+    svg = raster_to_svg(_sample_image(fmt))
     assert "<svg" in svg and "<path" in svg
 
 
-def test_apply_fill() -> None:
-    svg = raster_to_svg(_sample_image())
+@pytest.mark.parametrize("fmt", ["PNG", "JPEG", "WEBP"])
+def test_apply_fill(fmt: str) -> None:
+    svg = raster_to_svg(_sample_image(fmt))
     red = apply_fill(svg, "#ff0000")
     assert "#ff0000" in red
 


### PR DESCRIPTION
## Summary
- allow JPEG and WebP in tests
- clarify supported input formats in README
- exercise PNG/JPEG/WebP across API tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6842b140643c832d84992c5be0961e3b