### PR TITLE
Add configurable SVG output size

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Supported input types include PNG, JPEG, WebP, and any other format that Pillow 
 | `turnpolicy` | str | `minority` | Potrace turn policy |
 | `alphamax` | float | `1.0` | AlphaMax parameter |
 | `turdsize` | int | `2` | Suppress speckles smaller than this |
+| `size` | int | `250` | Output dimension (square pixels) |
 | `fill` | str | `None` | Optional fill color (e.g. `#ff0000`) |
 | `download` | bool | `false` | Return SVG as attachment |
 

--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,7 @@ async def vectorize(
     turnpolicy: str = Query("minority"),
     alphamax: float = Query(1.0),
     turdsize: int = Query(2),
+    size: int = Query(250, gt=0),
     fill: str | None = Query(None),
     download: bool = Query(False),
 ) -> Response | JSONResponse:
@@ -57,7 +58,7 @@ async def vectorize(
     if len(content) > 10 * 1024 * 1024:
         raise HTTPException(status_code=400, detail="File too large")
     try:
-        svg = raster_to_svg(content, threshold, turnpolicy, alphamax, turdsize)
+        svg = raster_to_svg(content, threshold, turnpolicy, alphamax, turdsize, size)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if fill:
@@ -79,6 +80,7 @@ async def vectorize_get(
     turnpolicy: str = Query("minority"),
     alphamax: float = Query(1.0),
     turdsize: int = Query(2),
+    size: int = Query(250, gt=0),
     fill: str | None = Query(None),
     download: bool = Query(False),
 ) -> Response | JSONResponse:
@@ -91,6 +93,7 @@ async def vectorize_get(
         turnpolicy=turnpolicy,
         alphamax=alphamax,
         turdsize=turdsize,
+        size=size,
         fill=fill,
         download=download,
     )

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -46,6 +46,15 @@ def test_vectorize_image_url(fmt: str, ext: str) -> None:
     assert "<svg" in resp.json()["svg"]
 
 
+def test_vectorize_custom_size() -> None:
+    client = TestClient(app)
+    with patch("urllib.request.urlopen", return_value=_Resp("PNG")):
+        resp = client.post("/vectorize?image_url=http://example.com/img.png&size=100")
+    assert resp.status_code == 200
+    body = resp.json()["svg"]
+    assert 'width="100"' in body and 'height="100"' in body
+
+
 @pytest.mark.parametrize(
     "fmt,ext",
     [

--- a/app/tests/test_tracing.py
+++ b/app/tests/test_tracing.py
@@ -20,6 +20,7 @@ def _sample_image(fmt: str = "PNG") -> bytes:
 def test_svg_generation(fmt: str) -> None:
     svg = raster_to_svg(_sample_image(fmt))
     assert "<svg" in svg and "<path" in svg
+    assert 'width="250"' in svg and 'height="250"' in svg
 
 
 @pytest.mark.parametrize("fmt", ["PNG", "JPEG", "WEBP"])
@@ -42,3 +43,8 @@ def test_threshold_effect() -> None:
     filled = raster_to_svg(buf.getvalue(), threshold=0)
     assert 'd=""' in empty
     assert 'd=""' not in filled
+
+
+def test_custom_size() -> None:
+    svg = raster_to_svg(_sample_image(), size=100)
+    assert 'width="100"' in svg and 'height="100"' in svg


### PR DESCRIPTION
## Summary
- allow raster_to_svg to scale SVG into a square of a given size
- expose `size` query param in API
- document the new parameter
- test custom size handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_b_6842c45c4f30832daeca192c12976303