### PR TITLE
Verify clean SVG output in JSON responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ Responses:
 - `400` on invalid input or download errors
 - `401` if authorization fails
 
+When calling the API programmatically, make sure to parse the JSON body and
+extract the `svg` field. Printing the raw HTTP response will show escaped
+characters (like backslashes) around the SVG data, but parsing the JSON will
+yield the clean `<svg...></svg>` string.
+
 ### `GET /vectorize`
 
 Vectorize an image by specifying its `image_url` in the query string. This makes

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -43,7 +43,9 @@ def test_vectorize_image_url(fmt: str, ext: str) -> None:
     with patch("urllib.request.urlopen", return_value=_Resp(fmt)):
         resp = client.post(f"/vectorize?image_url=http://example.com/img.{ext}")
     assert resp.status_code == 200
-    assert "<svg" in resp.json()["svg"]
+    body = resp.json()["svg"]
+    assert body.startswith("<svg") and body.endswith("</svg>")
+    assert "\\" not in body
 
 
 def test_vectorize_custom_size() -> None:
@@ -68,7 +70,9 @@ def test_vectorize_image_url_get(fmt: str, ext: str) -> None:
     with patch("urllib.request.urlopen", return_value=_Resp(fmt)):
         resp = client.get(f"/vectorize?image_url=http://example.com/img.{ext}")
     assert resp.status_code == 200
-    assert "<svg" in resp.json()["svg"]
+    body = resp.json()["svg"]
+    assert body.startswith("<svg") and body.endswith("</svg>")
+    assert "\\" not in body
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add assertion that SVG payload starts with `<svg` and ends with `</svg>`
- ensure response bodies have no backslashes
- document the need to parse JSON for the SVG output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684357d359fc832db24028c660ba11b4