### PR TITLE
Add simple GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ must include the token using one of the following methods:
 1. `Authorization: Bearer <token>` header
 2. `token=<token>` query parameter
 
+## Web interface
+
+Once the service is running you can visit
+`http://localhost:8080/` in your browser for a simple GUI. The page lets you
+upload an image or provide an image URL and tweak any query parameters before
+submitting the request. The server response is shown next to the form as both
+the raw SVG text and a rendered preview.
+
 ## API reference
 
 ### `POST /vectorize`

--- a/app/main.py
+++ b/app/main.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from fastapi import FastAPI, File, UploadFile, Query, HTTPException, Request
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse, Response, FileResponse
+from fastapi.staticfiles import StaticFiles
 import asyncio
 import urllib.request
 
 from .core.tracing import apply_fill, raster_to_svg
 
 app = FastAPI(title="vectorize-svc")
+BASE_DIR = Path(__file__).resolve().parent
+app.mount("/static", StaticFiles(directory=BASE_DIR / "static"), name="static")
+
+@app.get("/", include_in_schema=False)
+def index() -> FileResponse:
+    """Serve the front-end HTML page."""
+    return FileResponse(BASE_DIR / "static" / "index.html")
 
 # cache API token so we don't hit the environment on every request
 API_TOKEN = os.getenv("API_TOKEN")

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Vectorize Service</title>
+<style>
+body {font-family: Arial, sans-serif; margin: 20px; display:flex;}
+form {width: 45%;}
+#output {margin-left: 20px; width: 55%;}
+textarea {width: 100%; height: 300px;}
+#svg-display {border:1px solid #ccc; height:300px;}
+</style>
+</head>
+<body>
+<form id="vectorize-form">
+<h1>Vectorize Image</h1>
+<label>API Token <input type="text" id="token" name="token" placeholder="secret"></label><br>
+<label>Upload Image <input type="file" id="image" name="image"></label><br>
+<label>Image URL <input type="text" id="image_url" name="image_url" placeholder="https://example.com/image.png"></label><br>
+<label>Threshold <input type="number" id="threshold" value="128" min="0" max="255"></label><br>
+<label>Turn Policy
+<select id="turnpolicy">
+<option value="black">black</option>
+<option value="white">white</option>
+<option value="left">left</option>
+<option value="right">right</option>
+<option value="minority" selected>minority</option>
+<option value="majority">majority</option>
+<option value="random">random</option>
+</select>
+</label><br>
+<label>Alpha Max <input type="number" id="alphamax" value="1.0" step="0.1"></label><br>
+<label>Turd Size <input type="number" id="turdsize" value="2"></label><br>
+<label>Size <input type="number" id="size" value="250"></label><br>
+<label>Fill Color <input type="text" id="fill" placeholder="#ff0000"></label><br>
+<label>Download <input type="checkbox" id="download"></label><br>
+<button type="submit">Submit</button>
+</form>
+<div id="output">
+<textarea id="svg-text" readonly></textarea>
+<div id="svg-display"></div>
+</div>
+<script>
+document.getElementById('vectorize-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const params = new URLSearchParams();
+    params.append('threshold', document.getElementById('threshold').value);
+    params.append('turnpolicy', document.getElementById('turnpolicy').value);
+    params.append('alphamax', document.getElementById('alphamax').value);
+    params.append('turdsize', document.getElementById('turdsize').value);
+    params.append('size', document.getElementById('size').value);
+    if (document.getElementById('fill').value)
+        params.append('fill', document.getElementById('fill').value);
+    if (document.getElementById('download').checked)
+        params.append('download', 'true');
+    const token = document.getElementById('token').value;
+    if (token) params.append('token', token);
+    const imageUrl = document.getElementById('image_url').value;
+    if (imageUrl) params.append('image_url', imageUrl);
+
+    const url = '/vectorize?' + params.toString();
+
+    const files = document.getElementById('image').files;
+    let options = { method: 'POST', headers: {} };
+    if (files.length) {
+        const formData = new FormData();
+        formData.append('image', files[0]);
+        options.body = formData;
+    }
+    if (token) options.headers['Authorization'] = 'Bearer ' + token;
+    const response = await fetch(url, options);
+    if (!response.ok) {
+        document.getElementById('svg-text').value = 'Error: ' + response.status;
+        document.getElementById('svg-display').textContent = '';
+        return;
+    }
+    let svgText = '';
+    if (document.getElementById('download').checked) {
+        svgText = await response.text();
+    } else {
+        const data = await response.json();
+        svgText = data.svg;
+    }
+    document.getElementById('svg-text').value = svgText;
+    document.getElementById('svg-display').innerHTML = svgText;
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add basic web interface to submit vectorize requests
- mount static files and index route in FastAPI app
- document web interface usage in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_b_68436a431a08832d9786542bf386626f