### PR TITLE
Add advanced vectorization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ Supported input types include PNG, JPEG, WebP, and any other format that Pillow 
 | `alphamax` | float | `1.0` | `0.0`, `1.0`, `2.0` | <sub>Parameter that balances curve smoothness against detail. Increasing this makes curves smoother at the expense of small features. |
 | `turdsize` | int | `2` | `0`, `2`, `5` | <sub> Minimum size of speckles to keep in the output. Larger values remove more noise but may discard tiny details. |
 | `size` | int | `250` | `100`, `250`, `500` | <sub> Width and height of the square SVG output. Bigger values yield a larger vector graphic. |
+| `opticurve` | bool | `true` | `true`, `false` | <sub>Whether to apply Potrace's optimal curve fitting. Disable for raw, jagged paths. |
+| `opttolerance` | float | `0.2` | `0.0`, `0.5`, `1.0` | <sub>How closely the curves match the bitmap. Lower values preserve detail, higher values simplify. |
+| `background` | str | `None` | `#ffffff` | <sub>Background color to apply before tracing. Helpful for images with transparency. |
+| `stroke` | str | `None` | `#000000` | <sub>Optional hex color for the stroke outline. |
+| `stroke_width` | float | `1.0` | `0.5`, `1.0`, `2.0` | <sub>Width of the stroke when a stroke color is used. |
+| `invert` | bool | `false` | `true`, `false` | <sub>Invert the image colors before vectorizing. |
+| `passes` | int | `1` | `1`, `2`, `3` | <sub>Run multiple tracing passes to refine results. |
+| `autocrop` | bool | `false` | `true`, `false` | <sub>Crop transparent edges before tracing. |
 | `fill` | str | `None` | `#ff0000`, `#00ff00` | <sub> Optional hex color to fill the traced shapes. Leave unset for a transparent path. |
 | `download` | bool | `false` | `true`, `false` | <sub> If `true`, the endpoint responds with a downloadable SVG file. Otherwise it returns a JSON body containing the SVG string. |
 

--- a/app/main.py
+++ b/app/main.py
@@ -42,6 +42,14 @@ async def vectorize(
     alphamax: float = Query(1.0),
     turdsize: int = Query(2),
     size: int = Query(250, gt=0),
+    opticurve: bool = Query(True),
+    opttolerance: float = Query(0.2),
+    background: str | None = Query(None),
+    stroke: str | None = Query(None),
+    stroke_width: float = Query(1.0),
+    invert: bool = Query(False),
+    passes: int = Query(1, ge=1),
+    autocrop: bool = Query(False),
     fill: str | None = Query(None),
     download: bool = Query(False),
 ) -> Response | JSONResponse:
@@ -67,11 +75,24 @@ async def vectorize(
     if len(content) > 10 * 1024 * 1024:
         raise HTTPException(status_code=400, detail="File too large")
     try:
-        svg = raster_to_svg(content, threshold, turnpolicy, alphamax, turdsize, size)
+        svg = raster_to_svg(
+            content,
+            threshold,
+            turnpolicy,
+            alphamax,
+            turdsize,
+            size,
+            opticurve,
+            opttolerance,
+            background,
+            invert,
+            passes,
+            autocrop,
+        )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    if fill:
-        svg = apply_fill(svg, fill)
+    if fill or stroke or stroke_width:
+        svg = apply_fill(svg, fill, stroke, stroke_width)
     if download:
         return Response(
             content=svg,
@@ -90,6 +111,14 @@ async def vectorize_get(
     alphamax: float = Query(1.0),
     turdsize: int = Query(2),
     size: int = Query(250, gt=0),
+    opticurve: bool = Query(True),
+    opttolerance: float = Query(0.2),
+    background: str | None = Query(None),
+    stroke: str | None = Query(None),
+    stroke_width: float = Query(1.0),
+    invert: bool = Query(False),
+    passes: int = Query(1, ge=1),
+    autocrop: bool = Query(False),
     fill: str | None = Query(None),
     download: bool = Query(False),
 ) -> Response | JSONResponse:
@@ -103,6 +132,14 @@ async def vectorize_get(
         alphamax=alphamax,
         turdsize=turdsize,
         size=size,
+        opticurve=opticurve,
+        opttolerance=opttolerance,
+        background=background,
+        stroke=stroke,
+        stroke_width=stroke_width,
+        invert=invert,
+        passes=passes,
+        autocrop=autocrop,
         fill=fill,
         download=download,
     )

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -32,6 +32,14 @@ textarea {width: 100%; height: 300px;}
 <label>Alpha Max <input type="number" id="alphamax" value="1.0" step="0.1"></label><br>
 <label>Turd Size <input type="number" id="turdsize" value="2"></label><br>
 <label>Size <input type="number" id="size" value="250"></label><br>
+<label>Opticurve <input type="checkbox" id="opticurve" checked></label><br>
+<label>Simplification Tolerance <input type="number" id="opttolerance" value="0.2" step="0.1"></label><br>
+<label>Background <input type="text" id="background" placeholder="#ffffff"></label><br>
+<label>Stroke Color <input type="text" id="stroke" placeholder="#000000"></label><br>
+<label>Stroke Width <input type="number" id="stroke_width" value="1.0" step="0.1"></label><br>
+<label>Invert <input type="checkbox" id="invert"></label><br>
+<label>Passes <input type="number" id="passes" value="1" min="1"></label><br>
+<label>Auto Crop <input type="checkbox" id="autocrop"></label><br>
 <label>Fill Color <input type="text" id="fill" placeholder="#ff0000"></label><br>
 <label>Download <input type="checkbox" id="download"></label><br>
 <button type="submit">Submit</button>
@@ -49,6 +57,19 @@ document.getElementById('vectorize-form').addEventListener('submit', async (e) =
     params.append('alphamax', document.getElementById('alphamax').value);
     params.append('turdsize', document.getElementById('turdsize').value);
     params.append('size', document.getElementById('size').value);
+    if (!document.getElementById('opticurve').checked)
+        params.append('opticurve', 'false');
+    params.append('opttolerance', document.getElementById('opttolerance').value);
+    if (document.getElementById('background').value)
+        params.append('background', document.getElementById('background').value);
+    if (document.getElementById('stroke').value)
+        params.append('stroke', document.getElementById('stroke').value);
+    params.append('stroke_width', document.getElementById('stroke_width').value);
+    if (document.getElementById('invert').checked)
+        params.append('invert', 'true');
+    params.append('passes', document.getElementById('passes').value);
+    if (document.getElementById('autocrop').checked)
+        params.append('autocrop', 'true');
     if (document.getElementById('fill').value)
         params.append('fill', document.getElementById('fill').value);
     if (document.getElementById('download').checked)

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -129,3 +129,13 @@ def test_auth_query_param_get(fmt: str, ext: str) -> None:
                 f"/vectorize?image_url=http://example.com/img.{ext}&token=secret"
             )
         assert resp.status_code == 200
+
+
+def test_additional_params() -> None:
+    client = TestClient(app)
+    with patch("urllib.request.urlopen", return_value=_Resp("PNG")):
+        resp = client.post(
+            "/vectorize?image_url=http://example.com/img.png&opticurve=false&opttolerance=0.5&stroke=%23000000&stroke_width=2&invert=true&passes=2&autocrop=true",
+        )
+    assert resp.status_code == 200
+    assert "stroke=\"#000000\"" in resp.json()["svg"]

--- a/app/tests/test_tracing.py
+++ b/app/tests/test_tracing.py
@@ -64,3 +64,23 @@ def test_numeric_rounding() -> None:
     for num in numbers:
         if '.' in num:
             assert len(num.split('.')[1]) <= 1
+
+
+def test_apply_stroke() -> None:
+    svg = raster_to_svg(_sample_image())
+    styled = apply_fill(svg, fill="#00ff00", stroke="#000000", stroke_width=2.5)
+    assert "stroke=\"#000000\"" in styled
+    assert "stroke-width=\"2.5\"" in styled
+
+
+def test_extra_options() -> None:
+    svg = raster_to_svg(
+        _sample_image(),
+        opticurve=False,
+        opttolerance=0.5,
+        background="#ffffff",
+        invert=True,
+        passes=2,
+        autocrop=True,
+    )
+    assert svg.startswith("<svg")


### PR DESCRIPTION
## Summary
- add advanced tracing parameters like opticurve, stroke color, and more
- expose new parameters via API and front-end
- document all new options in README
- expand tests for new functionality

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684386044694832d91667f850d9136c0