### PR TITLE
Enhance index page UX

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -4,21 +4,47 @@
 <meta charset="UTF-8">
 <title>Vectorize Service</title>
 <style>
-body {font-family: Arial, sans-serif; margin: 20px; display:flex;}
-form {width: 45%;}
-#output {margin-left: 20px; width: 55%;}
-textarea {width: 100%; height: 300px;}
-#svg-display {border:1px solid #ccc; height:300px;}
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+#top {
+    display: flex;
+}
+form {
+    width: 45%;
+    margin-right: 20px;
+}
+form label {
+    display: block;
+    margin-bottom: 15px;
+    line-height: 1.4;
+}
+#output {
+    width: 55%;
+}
+textarea {
+    width: 100%;
+    height: 300px;
+}
+#svg-display {
+    border: 1px solid #ccc;
+    height: 300px;
+}
+#info {
+    margin-top: 40px;
+}
 </style>
 </head>
 <body>
+<div id="top">
 <form id="vectorize-form">
 <h1>Vectorize Image</h1>
-<label>API Token <input type="text" id="token" name="token" placeholder="secret"></label><br>
-<label>Upload Image <input type="file" id="image" name="image"></label><br>
-<label>Image URL <input type="text" id="image_url" name="image_url" placeholder="https://example.com/image.png"></label><br>
-<label>Threshold <input type="number" id="threshold" value="128" min="0" max="255"></label><br>
-<label>Turn Policy
+<label for="token"><a href="#token-info">API Token</a> <input type="text" id="token" name="token" placeholder="secret"></label><br>
+<label for="image"><a href="#image-info">Upload Image</a> <input type="file" id="image" name="image"></label><br>
+<label for="image_url"><a href="#image_url-info">Image URL</a> <input type="text" id="image_url" name="image_url" placeholder="https://example.com/image.png"></label><br>
+<label for="threshold"><a href="#threshold-info">Threshold</a> <input type="number" id="threshold" value="128" min="0" max="255"></label><br>
+<label for="turnpolicy"><a href="#turnpolicy-info">Turn Policy</a>
 <select id="turnpolicy">
 <option value="black">black</option>
 <option value="white">white</option>
@@ -29,25 +55,65 @@ textarea {width: 100%; height: 300px;}
 <option value="random">random</option>
 </select>
 </label><br>
-<label>Alpha Max <input type="number" id="alphamax" value="1.0" step="0.1"></label><br>
-<label>Turd Size <input type="number" id="turdsize" value="2"></label><br>
-<label>Size <input type="number" id="size" value="250"></label><br>
-<label>Opticurve <input type="checkbox" id="opticurve" checked></label><br>
-<label>Simplification Tolerance <input type="number" id="opttolerance" value="0.2" step="0.1"></label><br>
-<label>Background <input type="text" id="background" placeholder="#ffffff"></label><br>
-<label>Stroke Color <input type="text" id="stroke" placeholder="#000000"></label><br>
-<label>Stroke Width <input type="number" id="stroke_width" value="1.0" step="0.1"></label><br>
-<label>Invert <input type="checkbox" id="invert"></label><br>
-<label>Passes <input type="number" id="passes" value="1" min="1"></label><br>
-<label>Auto Crop <input type="checkbox" id="autocrop"></label><br>
-<label>Fill Color <input type="text" id="fill" placeholder="#ff0000"></label><br>
-<label>Download <input type="checkbox" id="download"></label><br>
+<label for="alphamax"><a href="#alphamax-info">Alpha Max</a> <input type="number" id="alphamax" value="1.0" step="0.1"></label><br>
+<label for="turdsize"><a href="#turdsize-info">Turd Size</a> <input type="number" id="turdsize" value="2"></label><br>
+<label for="size"><a href="#size-info">Size</a> <input type="number" id="size" value="250"></label><br>
+<label for="opticurve"><a href="#opticurve-info">Opticurve</a> <input type="checkbox" id="opticurve" checked></label><br>
+<label for="opttolerance"><a href="#opttolerance-info">Simplification Tolerance</a> <input type="number" id="opttolerance" value="0.2" step="0.1"></label><br>
+<label for="background"><a href="#background-info">Background</a> <input type="text" id="background" placeholder="#ffffff"></label><br>
+<label for="stroke"><a href="#stroke-info">Stroke Color</a> <input type="text" id="stroke" placeholder="#000000"></label><br>
+<label for="stroke_width"><a href="#stroke_width-info">Stroke Width</a> <input type="number" id="stroke_width" value="1.0" step="0.1"></label><br>
+<label for="invert"><a href="#invert-info">Invert</a> <input type="checkbox" id="invert"></label><br>
+<label for="passes"><a href="#passes-info">Passes</a> <input type="number" id="passes" value="1" min="1"></label><br>
+<label for="autocrop"><a href="#autocrop-info">Auto Crop</a> <input type="checkbox" id="autocrop"></label><br>
+<label for="fill"><a href="#fill-info">Fill Color</a> <input type="text" id="fill" placeholder="#ff0000"></label><br>
+<label for="download"><a href="#download-info">Download</a> <input type="checkbox" id="download"></label><br>
 <button type="submit">Submit</button>
 </form>
 <div id="output">
 <textarea id="svg-text" readonly></textarea>
 <div id="svg-display"></div>
 </div>
+</div>
+<section id="info">
+<h2>Parameter Descriptions</h2>
+<h4 id="token-info">API Token</h4>
+<p>Authentication token for the request. Use this field if sending an Authorization header is inconvenient.</p>
+<h4 id="image-info">Upload Image</h4>
+<p>Select an image file to upload for vectorization. Leave blank when using Image URL.</p>
+<h4 id="image_url-info">Image URL</h4>
+<p>URL of the image to vectorize when you are not uploading a file. The service downloads this remote image before processing.</p>
+<h4 id="threshold-info">Threshold</h4>
+<p>Brightness cutoff between 0 and 255 used to convert the image to black and white. Higher values treat more pixels as white before tracing.</p>
+<h4 id="turnpolicy-info">Turn Policy</h4>
+<p>Strategy Potrace uses to decide the direction of ambiguous turns. Different policies produce smoother, sharper, or more randomized paths.</p>
+<h4 id="alphamax-info">Alpha Max</h4>
+<p>Parameter that balances curve smoothness against detail. Increasing this makes curves smoother at the expense of small features.</p>
+<h4 id="turdsize-info">Turd Size</h4>
+<p>Minimum size of speckles to keep in the output. Larger values remove more noise but may discard tiny details.</p>
+<h4 id="size-info">Size</h4>
+<p>Width and height of the square SVG output. Bigger values yield a larger vector graphic.</p>
+<h4 id="opticurve-info">Opticurve</h4>
+<p>Whether to apply Potrace's optimal curve fitting. Disable for raw, jagged paths.</p>
+<h4 id="opttolerance-info">Simplification Tolerance</h4>
+<p>How closely the curves match the bitmap. Lower values preserve detail, higher values simplify.</p>
+<h4 id="background-info">Background</h4>
+<p>Background color to apply before tracing. Helpful for images with transparency.</p>
+<h4 id="stroke-info">Stroke Color</h4>
+<p>Optional hex color for the stroke outline.</p>
+<h4 id="stroke_width-info">Stroke Width</h4>
+<p>Width of the stroke when a stroke color is used.</p>
+<h4 id="invert-info">Invert</h4>
+<p>Invert the image colors before vectorizing.</p>
+<h4 id="passes-info">Passes</h4>
+<p>Run multiple tracing passes to refine results.</p>
+<h4 id="autocrop-info">Auto Crop</h4>
+<p>Crop transparent edges before tracing.</p>
+<h4 id="fill-info">Fill Color</h4>
+<p>Optional hex color to fill the traced shapes. Leave unset for a transparent path.</p>
+<h4 id="download-info">Download</h4>
+<p>If true, the endpoint responds with a downloadable SVG file. Otherwise it returns a JSON body containing the SVG string.</p>
+</section>
 <script>
 document.getElementById('vectorize-form').addEventListener('submit', async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- restyle front page layout with more spacing and containers
- link each form label to a new info section
- add detailed parameter descriptions under the form

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_68438b72d378832d8cef1990c87ed4fc