### PR TITLE
Update front-end layout

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,45 +1,46 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<meta charset="UTF-8">
-<title>Vectorize Service</title>
-<style>
-body {
-    font-family: Arial, sans-serif;
-    margin: 20px;
-}
-#top {
-    display: flex;
-}
-form {
-    width: 45%;
-    margin-right: 20px;
-}
-form label {
-    display: block;
-    margin-bottom: 15px;
-    line-height: 1.4;
-}
-#output {
-    width: 55%;
-}
-textarea {
-    width: 100%;
-    height: 300px;
-}
-#svg-display {
-    border: 1px solid #ccc;
-    height: 300px;
-}
-#info {
-    margin-top: 40px;
-}
-</style>
-</head>
-<body>
-<div id="top">
-<form id="vectorize-form">
-<h1>Vectorize Image</h1>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Vectorize Service</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+    <link rel="stylesheet" href="/static/assets/css/main.css" />
+    <style>
+      #main {
+        display: flex;
+      }
+      form {
+        width: 45%;
+        margin-right: 20px;
+      }
+      form label {
+        display: block;
+        margin-bottom: 15px;
+        line-height: 1.4;
+      }
+      #output {
+        width: 55%;
+      }
+      textarea {
+        width: 100%;
+        height: 300px;
+      }
+      #svg-display {
+        border: 1px solid #ccc;
+        height: 300px;
+      }
+      #info {
+        margin-top: 40px;
+      }
+    </style>
+  </head>
+  <body class="is-preload">
+    <header id="header">
+      <h1>Vectorize Image</h1>
+      <p>Convert raster graphics to SVG using potrace.</p>
+    </header>
+    <div id="main">
+      <form id="vectorize-form">
 <label for="token"><a href="#token-info">API Token</a> <input type="text" id="token" name="token" placeholder="secret"></label><br>
 <label for="image"><a href="#image-info">Upload Image</a> <input type="file" id="image" name="image"></label><br>
 <label for="image_url"><a href="#image_url-info">Image URL</a> <input type="text" id="image_url" name="image_url" placeholder="https://example.com/image.png"></label><br>
@@ -114,6 +115,14 @@ textarea {
 <h4 id="download-info">Download</h4>
 <p>If true, the endpoint responds with a downloadable SVG file. Otherwise it returns a JSON body containing the SVG string.</p>
 </section>
+<footer id="footer">
+  <ul class="icons">
+    <li>
+      <a href="https://github.com/sherafyk/vectorize-svc" class="icon brands fa-github"><span class="label">GitHub</span></a>
+    </li>
+  </ul>
+</footer>
+<script src="/static/assets/js/main.js"></script>
 <script>
 document.getElementById('vectorize-form').addEventListener('submit', async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- integrate HTML5 UP assets on the landing page
- tweak layout and add footer link

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68439340b5d8832d90b07f5d5c9cf2f3