### PR TITLE
Add API call copy feature

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -114,6 +114,25 @@
       box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.5);
     }
 
+    #api-container, #get-container {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      flex: 1;
+    }
+
+    #curl-text, #get-text {
+      width: 100%;
+      height: 80px;
+      padding: 0.5rem;
+      border: 1px solid #555;
+      border-radius: 4px;
+      resize: vertical;
+      background: #1a1a1a;
+      color: #fff;
+      box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.5);
+    }
+
     #svg-text {
       width: 100%;
       height: 200px;
@@ -269,6 +288,14 @@
         <button id="copy-btn" type="button">Copy SVG</button>
       </div>
       <div id="svg-display"></div>
+      <div id="api-container">
+        <textarea id="curl-text" readonly></textarea>
+        <button id="copy-curl-btn" type="button">Copy cURL</button>
+      </div>
+      <div id="get-container" style="display:none;">
+        <textarea id="get-text" readonly></textarea>
+        <button id="copy-get-btn" type="button">Copy GET URL</button>
+      </div>
     </div>
 
 
@@ -378,9 +405,36 @@ document.getElementById('vectorize-form').addEventListener('submit', async (e) =
     }
     document.getElementById('svg-text').value = svgText;
     document.getElementById('svg-display').innerHTML = svgText;
+
+    const curlParts = [];
+    curlParts.push('curl');
+    if (files.length) {
+        curlParts.push('-F');
+        curlParts.push('image=@' + (files[0].name || 'image.png'));
+    } else {
+        curlParts.push('-X');
+        curlParts.push('POST');
+    }
+    if (token)
+        curlParts.push('-H "Authorization: Bearer ' + token + '"');
+    curlParts.push('"' + window.location.origin + url + '"');
+    document.getElementById('curl-text').value = curlParts.join(' ');
+
+    if (!files.length) {
+        document.getElementById('get-text').value = window.location.origin + url;
+        document.getElementById('get-container').style.display = 'flex';
+    } else {
+        document.getElementById('get-container').style.display = 'none';
+    }
 });
 document.getElementById('copy-btn').addEventListener('click', () => {
     navigator.clipboard.writeText(document.getElementById('svg-text').value);
+});
+document.getElementById('copy-curl-btn').addEventListener('click', () => {
+    navigator.clipboard.writeText(document.getElementById('curl-text').value);
+});
+document.getElementById('copy-get-btn').addEventListener('click', () => {
+    navigator.clipboard.writeText(document.getElementById('get-text').value);
 });
 </script>
 


### PR DESCRIPTION
## Summary
- add new containers to show generated API calls
- implement JS to generate cURL and GET snippets
- allow copying API calls to clipboard from frontend

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6847c0148298832db194b9b6f1374241